### PR TITLE
Fix dependencies format

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -14,7 +14,7 @@ relationships:
 
 # The build-time dependencies of the app.
 dependencies:
-    python:
+    python3:
        pipenv: '*'
 
 hooks:


### PR DESCRIPTION
Python version in the dependencies section of the app config file should be now explicit, there was a backward incompatible change in Python dependencies format https://docs.platform.sh/configuration/app/build.html#python-dependencies.